### PR TITLE
Define a comment character and scope. Fixes #1

### DIFF
--- a/scoped-properties/language-apache.cson
+++ b/scoped-properties/language-apache.cson
@@ -1,3 +1,4 @@
 '.source.apache-config':
   'editor':
+    'commentStart': '# '
     'foldEndPattern': '^[ ]*(?x)\n\t\t(</(?i:FilesMatch|Files|DirectoryMatch|Directory|LocationMatch|Location|VirtualHost|IfModule|IfDefine|Perl)>\n\t\t)'


### PR DESCRIPTION
This provides a comment character to prevent from using the atom wide default of `/* */`
