### PR TITLE
Swap out spaces for all whitespace characters

### DIFF
--- a/grammars/apache.cson
+++ b/grammars/apache.cson
@@ -35,11 +35,11 @@
         'name': 'entity.name.tag.apache-config'
       '6':
         'name': 'punctuation.definition.tag.apache-config'
-    'match': '^[\s]*(<)([a-zA-Z0-9:]+)[^>]*(>(<)/)(\\2)(>)'
+    'match': '^[\\s]*(<)([a-zA-Z0-9:]+)[^>]*(>(<)/)(\\2)(>)'
     'name': 'meta.tag.any.html'
   }
   {
-    'begin': '^[\s]*((<)(VirtualHost)(?:[\s]+([^>]+))?(>))'
+    'begin': '^[\\s]*((<)(VirtualHost)(?:[\\s]+([^>]+))?(>))'
     'beginCaptures':
       '1':
         'name': 'meta.tag.apache-config'
@@ -51,7 +51,7 @@
         'name': 'meta.toc-list.virtual-host.apache-config'
       '5':
         'name': 'punctuation.definition.tag.apache-config'
-    'end': '^[\s]*((</)(VirtualHost)[^>]*(>))'
+    'end': '^[\\s]*((</)(VirtualHost)[^>]*(>))'
     'endCaptures':
       '1':
         'name': 'meta.tag.apache-config'
@@ -69,7 +69,7 @@
     ]
   }
   {
-    'begin': '^[\s]*((<)(Directory(?:Match)?)(?:[\s]+([^>]+))?(>))'
+    'begin': '^[\\s]*((<)(Directory(?:Match)?)(?:[\\s]+([^>]+))?(>))'
     'beginCaptures':
       '1':
         'name': 'meta.tag.apache-config'
@@ -81,7 +81,7 @@
         'name': 'meta.toc-list.directory.apache-config'
       '5':
         'name': 'punctuation.definition.tag.apache-config'
-    'end': '^[\s]*((</)(Directory(?:Match)?)[^>]*(>))'
+    'end': '^[\\s]*((</)(Directory(?:Match)?)[^>]*(>))'
     'endCaptures':
       '1':
         'name': 'meta.tag.apache-config'
@@ -99,7 +99,7 @@
     ]
   }
   {
-    'begin': '^[\s]*((<)(Location(?:Match)?)(?:[\s]+([^>]+))?(>))'
+    'begin': '^[\\s]*((<)(Location(?:Match)?)(?:[\\s]+([^>]+))?(>))'
     'beginCaptures':
       '1':
         'name': 'meta.tag.apache-config'
@@ -111,7 +111,7 @@
         'name': 'meta.toc-list.location.apache-config'
       '5':
         'name': 'punctuation.definition.tag.apache-config'
-    'end': '^[\s]*((</)(Location(?:Match)?)[^>]*(>))'
+    'end': '^[\\s]*((</)(Location(?:Match)?)[^>]*(>))'
     'endCaptures':
       '1':
         'name': 'meta.tag.apache-config'
@@ -146,14 +146,14 @@
     ]
   }
   {
-    'begin': '^[\s]*\\b(RewriteCond)\\b'
+    'begin': '^[\\s]*\\b(RewriteCond)\\b'
     'captures':
       '1':
         'name': 'support.constant.rewritecond.apache-config'
     'end': '$'
     'patterns': [
       {
-        'begin': '[\s]+'
+        'begin': '[\\s]+'
         'end': '$'
         'patterns': [
           {
@@ -164,7 +164,7 @@
             'name': 'string.regexp.rewrite-test.apache-config'
           }
           {
-            'begin': '[\s]+'
+            'begin': '[\\s]+'
             'end': '$'
             'patterns': [
               {
@@ -175,7 +175,7 @@
                 'captures':
                   '1':
                     'name': 'string.regexp.rewrite-operator.apache-config'
-                'match': '[\s]+(\\[[^\\]]+\\])'
+                'match': '[\\s]+(\\[[^\\]]+\\])'
               }
             ]
           }
@@ -184,14 +184,14 @@
     ]
   }
   {
-    'begin': '^[\s]*\\b(RewriteRule)\\b'
+    'begin': '^[\\s]*\\b(RewriteRule)\\b'
     'captures':
       '1':
         'name': 'support.constant.rewriterule.apache-config'
     'end': '$'
     'patterns': [
       {
-        'begin': '[\s]+'
+        'begin': '[\\s]+'
         'end': '$'
         'patterns': [
           {
@@ -202,7 +202,7 @@
             'name': 'string.regexp.rewrite-pattern.apache-config'
           }
           {
-            'begin': '[\s]+'
+            'begin': '[\\s]+'
             'end': '$'
             'patterns': [
               {
@@ -216,7 +216,7 @@
                 'captures':
                   '1':
                     'name': 'string.regexp.rewrite-operator.apache-config'
-                'match': '[\s]+(\\[[^\\]]+\\])'
+                'match': '[\\s]+(\\[[^\\]]+\\])'
               }
             ]
           }


### PR DESCRIPTION
Swaps out all `[ ]` for `[\s]` to match all whitespace characters, not just new lines. Fixes #3 
