### PR TITLE
Add support for single-quoted strings

### DIFF
--- a/grammars/apache.cson
+++ b/grammars/apache.cson
@@ -250,6 +250,23 @@
     ]
   }
   {
+    'begin': '\''
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.apache-config'
+    'end': '\'(?!\')'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.apache-config'
+    'name': 'string.quoted.double.apache-config'
+    'patterns': [
+      {
+        'match': '\'\''
+        'name': 'constant.character.escape.apostrophe.apache'
+      }
+    ]
+  }
+  {
     'begin': '(</?)([a-zA-Z]+)'
     'captures':
       '1':

--- a/grammars/apache.cson
+++ b/grammars/apache.cson
@@ -250,18 +250,18 @@
     ]
   }
   {
-    'begin': '\''
+    'begin': "'"
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.apache-config'
-    'end': '\'(?!\')'
+    'end': "'(?!')"
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.apache-config'
     'name': 'string.quoted.double.apache-config'
     'patterns': [
       {
-        'match': '\'\''
+        'match': "''"
         'name': 'constant.character.escape.apostrophe.apache'
       }
     ]


### PR DESCRIPTION
This PR tries to add support for strings marked up with single quotation marks.

I don’t know if there’s a better way to achieve this.