### PR TITLE
Fix incorrect tab-stops for VirtualHost snippet

### DIFF
--- a/snippets/language-apache.cson
+++ b/snippets/language-apache.cson
@@ -10,4 +10,4 @@
     'body': 'Options ${1:${2:All }${3:ExecCGI }${4:FollowSymLinks }${5:Includes }${6:IncludesNOEXEC }${7:Indexes }${8:MultiViews }${9:SymLinksIfOwnerMatch}}'
   'Virtual Host':
     'prefix': 'vhost'
-    'body': '<VirtualHost ${1:example.org}>\n\tServerAdmin webmaster@$1\n\tDocumentRoot /www/vhosts/$1\n\tServerName $1\n\tErrorLog logs/$1-error_log\n\tCustomLog logs/$1-access_log common\n</VirtualHost>'
+    'body': '<VirtualHost ${1:example.org}>\n\tServerAdmin ${2:webmaster@example.org}\n\tDocumentRoot ${3:/www/vhosts/}\n\tServerName $4\n\tErrorLog ${5:logs/error_log}\n\tCustomLog ${6:logs/access_log common}\n</VirtualHost>'


### PR DESCRIPTION
I have the [Sublime-Style-Column-Selection](https://github.com/bigfive/atom-sublime-select) package installed, which enables multiple cursors to be edited/selected. I think it screws with the incorrectly-written tab-stops in the VirtualHost snippet:

<img src="https://cloud.githubusercontent.com/assets/2346707/13560877/292d5df2-e479-11e5-8da7-a015b2eba7af.gif" width="316" />

This PR fixes it so hitting tab works properly:

<img src="https://cloud.githubusercontent.com/assets/2346707/13560900/59746410-e479-11e5-8782-68ad07fe449d.gif" width="312" />