### PR TITLE
Fix typo in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Syntax support for Apache configuration files in Atom
 
-Contributions are welcome and bonus are awarded for pull requests. Please fork and send a pull requests for updates to grammars, snippets or documentation.
+Contributions are welcome and bonus are awarded for pull requests.
+Please fork and send a pull request for updates to grammars, snippets or
+documentation.


### PR DESCRIPTION
This PR simply kills an incorrect plural:

> Please fork and send a pull request~~**s**~~

This is also wrong, too:

> Contributions are welcome and bonus are awarded

I've left the latter unfixed, though, as it's unclear if you meant to write *"bonus points"* or *"bonuses"*.