### PR TITLE
Tokenize arguments for Files/FilesMatch directives

### DIFF
--- a/grammars/apache.cson
+++ b/grammars/apache.cson
@@ -99,6 +99,36 @@
     ]
   }
   {
+    'begin': '^[\\s]*((<)(Files(?:Match)?)(?:[\\s]+([^>]+))?(>))'
+    'beginCaptures':
+      '1':
+        'name': 'meta.tag.apache-config'
+      '2':
+        'name': 'punctuation.definition.tag.apache-config'
+      '3':
+        'name': 'entity.name.tag.apache-config'
+      '4':
+        'name': 'meta.toc-list.files.apache-config'
+      '5':
+        'name': 'punctuation.definition.tag.apache-config'
+    'end': '^[\\s]*((</)(Files(?:Match)?)[^>]*(>))'
+    'endCaptures':
+      '1':
+        'name': 'meta.tag.apache-config'
+      '2':
+        'name': 'punctuation.definition.tag.apache-config'
+      '3':
+        'name': 'entity.name.tag.apache-config'
+      '4':
+        'name': 'punctuation.definition.tag.apache-config'
+    'name': 'meta.files.apache-config'
+    'patterns': [
+      {
+        'include': '$base'
+      }
+    ]
+  }
+  {
     'begin': '^[\\s]*((<)(Location(?:Match)?)(?:[\\s]+([^>]+))?(>))'
     'beginCaptures':
       '1':


### PR DESCRIPTION
Currently, the `Directory`, `DirectoryMatch`, `Location`, `LocationMatch`, and `VirtualHost` directives tokenize the arguments they accept (respectively). This is great because I can style those DOM elements with my Atom stylesheet (to color them like strings and such).

<img width="545" alt="screen shot 2016-10-26 at 3 45 22 pm" src="https://cloud.githubusercontent.com/assets/872474/19747906/55e0620a-9b93-11e6-9cc5-bedb6dd10a79.png">

However, this package does not tokenize the arguments for the `Files` and `FilesMatch` directives, even though the syntax is essentially the same. This PR adds grammar rules for these directives.

@jacobbednarz, please let me know if you have any concerns or changes to request.

Thanks very much,
Caleb