### PR TITLE
Allow all whitespace characters in `RewriteRule`

### DIFF
--- a/grammars/apache.cson
+++ b/grammars/apache.cson
@@ -228,7 +228,7 @@
             'include': '#vars'
           }
           {
-            'match': '[^ %]+'
+            'match': '[^\\s%]+'
             'name': 'string.regexp.rewrite-pattern.apache-config'
           }
           {
@@ -239,7 +239,7 @@
                 'include': '#vars'
               }
               {
-                'match': '[^ %\\n]+'
+                'match': '[^\\s%\\n]+'
                 'name': 'string.other.rewrite-substitution.apache-config'
               }
               {


### PR DESCRIPTION
Updates the regex matches to use `\\s` for whitespace characters instead
of a hardcoded whitespace.

Fixes #15